### PR TITLE
added the possibility to have a flat map, without nested objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ module.exports = function (config) {
 
 	config = config || {};
 	var origin = config.filename || "urls.json",
-			firstFile,
-			directoryStructure = {};
+		flat = typeof config.flat !== 'undefined' ? config.flat : true,
+		firstFile,
+		directoryStructure = {};
 
 	function directoryMap(file, enc, callback) {
 		/*jshint validthis:true*/
@@ -39,12 +40,12 @@ module.exports = function (config) {
 			var parent = directoryStructure;
 
 			segments.forEach(function(seg, index){
-				if (index === segments.length -1){
+				if (index === segments.length-1){
 					parent[seg] = path.replace(/\\/g,"/");
-				} else {
+				} else if(flat) {
 					parent[seg] = parent[seg] || {};
+					parent = parent[seg];
 				}
-				parent = parent[seg];
 			});
 		}
 		return callback();

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function (config) {
 
 	config = config || {};
 	var origin = config.filename || "urls.json",
-		flat = typeof config.flat !== 'undefined' ? config.flat : true,
+		subOjects = typeof config.subOjects !== 'undefined' ? config.subOjects : true,
 		firstFile,
 		directoryStructure = {};
 
@@ -42,7 +42,7 @@ module.exports = function (config) {
 			segments.forEach(function(seg, index){
 				if (index === segments.length-1){
 					parent[seg] = path.replace(/\\/g,"/");
-				} else if(!flat) {
+				} else if(subOjects) {
 					parent[seg] = parent[seg] || {};
 					parent = parent[seg];
 				}

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function (config) {
 			segments.forEach(function(seg, index){
 				if (index === segments.length-1){
 					parent[seg] = path.replace(/\\/g,"/");
-				} else if(flat) {
+				} else if(!flat) {
 					parent[seg] = parent[seg] || {};
 					parent = parent[seg];
 				}


### PR DESCRIPTION
Hi

I used your Gulp plugin but in my situation I needed a JSON file without the objects nested in it, just one flat object with the filenames and corresponding paths.

I've made some small changes to have that option when setting up the plugin in your Gulpfile.

`gulp.task('mapTemplates', function() {
	gulp.src(paths.main + '/**/*.tpl.html')
		.pipe(directoryMap({
			filename: 'templates.json',
			flat: true
		}))
		.pipe(gulp.dest(paths.app))
		.pipe(browserSync.stream());
});`

The `flat: true` makes sure you get a JSON file with just one flat object in which all the files of a certain type are mapped.

Regards,
Denis